### PR TITLE
pass CMAKE_TOOLCHAIN_FILE to h3

### DIFF
--- a/c_src/cmake/FindH3.cmake
+++ b/c_src/cmake/FindH3.cmake
@@ -43,6 +43,7 @@ ExternalProject_Add(external-h3
                     -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}
                     -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}
                     -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS_${BUILD_TYPE_UC}}
+                    -DCMAKE_TOOLCHAIN_FILE=$ENV{CMAKE_TOOLCHAIN_FILE}
   )
 
 add_library(H3::H3 STATIC IMPORTED)


### PR DESCRIPTION
H3 gets built through a nested cmake call which loses the `CMAKE_TOOLCHAIN_FILE`.
This patch passes this variable so that the h3 dependency can be cross compiled.